### PR TITLE
fix requirements file syntax

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-ipykernel = "^5.3.4"
-sparqlkernel ="^1.3.0"
-matplotlib = "^3.4.2"
-plotly = "^4.14.3"
-mapclassify = "^2.4.2"
-pandas = "^1.2.4"
+ipykernel~=5.3.4
+sparqlkernel~=1.3.0
+matplotlib~=3.4.2
+plotly~=4.14.3
+mapclassify~=2.4.2
+pandas~=1.2.4
 git+https://github.com/zazuko/graphly.git


### PR DESCRIPTION
`pip` doesn't like the format of the requirements file:

```
ERROR: Invalid requirement: 'ipykernel = "^5.3.4"' (from line 1 of requirements.txt)
```

 This PR fixes the syntax. 